### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ steps:
   - wait: ~
     continue_on_failure: true
   - plugins:
-      checkstyle-annotate:
-        artifacts: tmp/checkstyle-*.xml
+      - checkstyle-annotate:
+          artifacts: tmp/checkstyle-*.xml
 ```
 
 ## Configuration


### PR DESCRIPTION
Hi @martinbaillie! 😊

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.